### PR TITLE
feat: 車両規格マスタを追加し、AI推論プロンプトに組み込み

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -1,4 +1,60 @@
 
+// 車両規格マスタ（荷台寸法・容積の基準値）
+export interface TruckSpec {
+  maxCapacity: number;      // 最大積載量 (t)
+  bedLength: number;        // 荷台長 (m)
+  bedWidth: number;         // 荷台幅 (m)
+  bedHeight: number;        // あおり高 (m)
+  levelVolume: number;      // すり切り容量 (m³)
+  heapVolume: number;       // 山盛り容量 (m³) ※係数1.3
+  soilEquivalent: number;   // 土砂換算容量 (m³) ※比重1.8で計算
+}
+
+export const TRUCK_SPECS: Record<string, TruckSpec> = {
+  '2t': {
+    maxCapacity: 2,
+    bedLength: 3.0,
+    bedWidth: 1.6,
+    bedHeight: 0.32,
+    levelVolume: 1.5,
+    heapVolume: 2.0,
+    soilEquivalent: 1.1
+  },
+  '4t': {
+    maxCapacity: 4,
+    bedLength: 3.4,
+    bedWidth: 2.06,
+    bedHeight: 0.34,
+    levelVolume: 2.4,
+    heapVolume: 3.1,
+    soilEquivalent: 2.2
+  },
+  '8t': {
+    maxCapacity: 8,
+    bedLength: 4.0,
+    bedWidth: 2.2,
+    bedHeight: 0.40,
+    levelVolume: 3.5,
+    heapVolume: 4.6,
+    soilEquivalent: 4.4
+  },
+  '10t': {
+    maxCapacity: 10,
+    bedLength: 5.3,
+    bedWidth: 2.3,
+    bedHeight: 0.50,
+    levelVolume: 6.0,
+    heapVolume: 7.8,
+    soilEquivalent: 5.5
+  }
+};
+
+// 車両規格をプロンプト用テキストに変換
+export const TRUCK_SPECS_PROMPT = Object.entries(TRUCK_SPECS)
+  .map(([name, spec]) =>
+    `- ${name}ダンプ: 荷台${spec.bedLength}m×${spec.bedWidth}m×${spec.bedHeight}m, すり切り${spec.levelVolume}m³, 山盛り${spec.heapVolume}m³, 最大積載${spec.maxCapacity}t`
+  ).join('\n');
+
 export const SYSTEM_PROMPT = `あなたは建設廃棄物（ガラ）の重量推論エキスパートです。
 監視カメラまたは手動撮影された画像から、荷台の荷姿を解析し重量を推定します。
 

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,7 +1,7 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import { saveCostEntry } from './costTracker';
 import { EstimationResult, AnalysisHistory, StockItem, ExtractedFeature, ChatMessage } from "../types";
-import { SYSTEM_PROMPT } from "../constants";
+import { SYSTEM_PROMPT, TRUCK_SPECS_PROMPT } from "../constants";
 import { getReferenceImages } from './referenceImages';
 
 // APIキーがGoogleAIStudioの無料枠かどうかをチェック
@@ -107,8 +107,17 @@ async function runSingleInference(
 
 ${maxCapacityInstruction}
 
+【車両規格別 荷台容積（基準値）】
+${TRUCK_SPECS_PROMPT}
+※ すり切り=あおり高さまで、山盛り=すり切り×1.3
+
 【重量計算の基準】
 重量 = 見かけ体積(m³) × 密度(t/m³) × (1 - 空隙率)
+
+■ 体積の判定方法
+1. 車両規格を特定し、上記の基準容積を参照
+2. 荷台の埋まり具合を目視で判定（例: すり切りの80%、山盛り等）
+3. 基準容積 × 埋まり具合 = 見かけ体積
 
 ■ 素材別密度（参考値）
 - 土砂: 1.8 t/m³


### PR DESCRIPTION
- constants.ts に TRUCK_SPECS（2t/4t/8t/10t）を定義
- 荷台寸法・すり切り容量・山盛り容量を明記
- geminiService.ts のプロンプトで基準容積を参照するよう指示
- 体積判定の手順を明確化（車両特定→基準容積×埋まり具合）