### PR TITLE
fix: 車両登録の容量制限対策と画像圧縮を追加

### DIFF
--- a/services/referenceImages.ts
+++ b/services/referenceImages.ts
@@ -22,15 +22,20 @@ export const getReferenceImages = (): RegisteredVehicle[] => {
 };
 
 // 車両を追加
-export const addVehicle = (vehicle: Omit<RegisteredVehicle, 'id'>): RegisteredVehicle => {
+export const addVehicle = (vehicle: Omit<RegisteredVehicle, 'id'>): RegisteredVehicle | null => {
   const vehicles = getReferenceImages();
   const newVehicle: RegisteredVehicle = {
     ...vehicle,
     id: crypto.randomUUID()
   };
   vehicles.push(newVehicle);
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(vehicles));
-  return newVehicle;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(vehicles));
+    return newVehicle;
+  } catch (e) {
+    console.error('車両登録エラー（容量オーバーの可能性）:', e);
+    return null;
+  }
 };
 
 // 車両を更新


### PR DESCRIPTION
- 画像を800px/70%品質に圧縮して保存
- localStorage容量オーバー時のエラーハンドリングを追加
- エラーメッセージをUIに表示