### PR TITLE
fix: ストック保存時にも画像圧縮を適用し容量問題を解決

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -288,7 +288,7 @@ const App: React.FC = () => {
                 result: merged, // 最新の推定結果（後方互換性）
                 estimations: [merged], // 推定結果の履歴（ランごとに追加）
               };
-              saveStockItem(stockItem);
+              await saveStockItem(stockItem);
             }
             setStockItems(getStockItems());
           } catch (err) {
@@ -404,7 +404,7 @@ const App: React.FC = () => {
               setCurrentBase64Images([base64]);
               startAnalysis([base64], [url], false, capacity);
             }}
-            onStock={currentId ? undefined : () => {
+            onStock={currentId ? undefined : async () => {
               const dataUrl = 'data:image/jpeg;base64,' + pendingCapture.base64;
               const newItem: StockItem = {
                 id: crypto.randomUUID(),
@@ -412,7 +412,7 @@ const App: React.FC = () => {
                 base64Images: [pendingCapture.base64],
                 imageUrls: [dataUrl],
               };
-              saveStockItem(newItem);
+              await saveStockItem(newItem);
               setStockItems(getStockItems());
               setPendingCapture(null);
             }}
@@ -601,8 +601,8 @@ const App: React.FC = () => {
       {showStockList && (
         <StockList
           items={stockItems}
-          onAdd={(item) => {
-            saveStockItem(item);
+          onAdd={async (item) => {
+            await saveStockItem(item);
             setStockItems(getStockItems());
           }}
           onUpdate={(id, updates) => {
@@ -639,8 +639,8 @@ const App: React.FC = () => {
       {showReportView && (
         <ReportView
           items={stockItems}
-          onAdd={(item) => {
-            saveStockItem(item);
+          onAdd={async (item) => {
+            await saveStockItem(item);
             setStockItems(getStockItems());
           }}
           onUpdate={(id, updates) => {

--- a/components/ReferenceImageSettings.tsx
+++ b/components/ReferenceImageSettings.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Truck, Plus, Trash2, Camera, FileText, Loader2, Pencil } fro
 import { getReferenceImages, addVehicle, updateVehicle, deleteVehicle, RegisteredVehicle } from '../services/referenceImages';
 import { analyzeShaken } from '../services/shakenAnalyzer';
 import { convertPdfToImage, isPdf } from '../services/pdfConverter';
+import { compressImage } from '../services/imageUtils';
 
 interface ReferenceImageSettingsProps {
   isOpen: boolean;
@@ -62,29 +63,6 @@ const ReferenceImageSettings: React.FC<ReferenceImageSettingsProps> = ({ isOpen,
         setAnalyzing(false);
       }
     }
-  };
-
-  // 画像を圧縮
-  const compressImage = (base64: string, maxWidth: number = 800): Promise<string> => {
-    return new Promise((resolve) => {
-      const img = new Image();
-      img.onload = () => {
-        const canvas = document.createElement('canvas');
-        let width = img.width;
-        let height = img.height;
-        if (width > maxWidth) {
-          height = (height * maxWidth) / width;
-          width = maxWidth;
-        }
-        canvas.width = width;
-        canvas.height = height;
-        const ctx = canvas.getContext('2d');
-        ctx?.drawImage(img, 0, 0, width, height);
-        const compressed = canvas.toDataURL('image/jpeg', 0.7).split(',')[1];
-        resolve(compressed);
-      };
-      img.src = 'data:image/jpeg;base64,' + base64;
-    });
   };
 
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/services/imageUtils.ts
+++ b/services/imageUtils.ts
@@ -1,0 +1,71 @@
+// 画像圧縮ユーティリティ
+
+/**
+ * base64画像を圧縮する
+ * @param base64 - 元のbase64画像データ
+ * @param maxWidth - 最大幅（デフォルト: 800px）
+ * @param quality - JPEG品質（デフォルト: 0.7）
+ * @returns 圧縮されたbase64画像データ
+ */
+export const compressImage = (
+  base64: string,
+  maxWidth: number = 800,
+  quality: number = 0.7
+): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      try {
+        const canvas = document.createElement('canvas');
+        let width = img.width;
+        let height = img.height;
+
+        if (width > maxWidth) {
+          height = (height * maxWidth) / width;
+          width = maxWidth;
+        }
+
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          resolve(base64); // フォールバック
+          return;
+        }
+        ctx.drawImage(img, 0, 0, width, height);
+        const compressed = canvas.toDataURL('image/jpeg', quality).split(',')[1];
+        resolve(compressed);
+      } catch (e) {
+        console.error('画像圧縮エラー:', e);
+        resolve(base64); // フォールバック
+      }
+    };
+    img.onerror = () => {
+      resolve(base64); // フォールバック
+    };
+    // base64がすでにdata URLの場合とそうでない場合に対応
+    if (base64.startsWith('data:')) {
+      img.src = base64;
+    } else {
+      img.src = 'data:image/jpeg;base64,' + base64;
+    }
+  });
+};
+
+/**
+ * localStorageの使用量を取得（概算）
+ */
+export const getLocalStorageUsage = (): { used: number; total: number; percent: number } => {
+  let used = 0;
+  for (const key in localStorage) {
+    if (localStorage.hasOwnProperty(key)) {
+      used += localStorage[key].length * 2; // UTF-16 = 2 bytes per char
+    }
+  }
+  const total = 5 * 1024 * 1024; // 約5MB
+  return {
+    used,
+    total,
+    percent: Math.round((used / total) * 100)
+  };
+};


### PR DESCRIPTION
- 共通の画像圧縮ユーティリティ(imageUtils.ts)を追加
- saveStockItemをasync化し画像を800px/60%品質に圧縮
- 車両登録の圧縮処理を共通化
- localStorage使用量取得関数を追加