### PR TITLE
feat: 実測値トン数のフォントサイズを約2倍に拡大

### DIFF
--- a/components/AnalysisResult.tsx
+++ b/components/AnalysisResult.tsx
@@ -85,8 +85,8 @@ const AnalysisResult: React.FC<AnalysisResultProps> = ({
               <div className="w-px h-8 bg-slate-600" />
               <div className="flex items-baseline gap-1">
                 <span className="text-xs text-slate-400 font-bold">実測</span>
-                <span className="text-4xl font-black text-green-400">{actualTonnage.toFixed(1)}</span>
-                <span className="text-lg font-bold text-slate-400">t</span>
+                <span className="text-7xl font-black text-green-400">{actualTonnage.toFixed(1)}</span>
+                <span className="text-2xl font-bold text-slate-400">t</span>
               </div>
               {errorRate !== null && (
                 <div className={`px-3 py-1 rounded text-sm font-black ${Math.abs(errorRate) < 5 ? 'bg-green-500' : Math.abs(errorRate) < 15 ? 'bg-yellow-500' : 'bg-red-500'} text-white`}>
@@ -132,7 +132,7 @@ const AnalysisResult: React.FC<AnalysisResultProps> = ({
 
           {/* 実測値入力 */}
           <div className="flex-1 flex items-center gap-1">
-            <span className="text-[10px] text-slate-500 font-bold">実測</span>
+            <span className="text-xs text-slate-500 font-bold">実測</span>
             <input
               type="number"
               inputMode="decimal"
@@ -140,11 +140,11 @@ const AnalysisResult: React.FC<AnalysisResultProps> = ({
               value={inputValue}
               onChange={(e) => { setInputValue(e.target.value); setIsSaved(false); }}
               placeholder="0.0"
-              className={`w-20 h-8 px-2 rounded font-bold text-lg outline-none ${
+              className={`w-28 h-12 px-2 rounded font-bold text-3xl outline-none ${
                 isSaved ? 'bg-green-500/20 text-green-400 border border-green-500/50' : 'bg-slate-800 text-white border border-slate-700'
               }`}
             />
-            <span className="text-slate-500 text-sm font-bold">t</span>
+            <span className="text-slate-500 text-lg font-bold">t</span>
             <button
               onClick={handleSave}
               disabled={isSaved || !inputValue}


### PR DESCRIPTION
老眼対策のため、実測値トン数の表示を見やすく拡大：
- フルスクリーンモード: text-4xl → text-7xl
- 通常表示モード入力欄: text-lg → text-3xl, 高さ・幅も拡大
- 単位(t)のサイズも適宜調整