### PR TITLE
fix: 4tダンプのすり切り容量を実務値に修正

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -26,7 +26,7 @@ export const TRUCK_SPECS: Record<string, TruckSpec> = {
     bedWidth: 2.06,
     bedHeight: 0.34,
     levelVolume: 2.0,
-    heapVolume: 2.6,
+    heapVolume: 2.4,
     soilEquivalent: 2.2
   },
   '増トン': {


### PR DESCRIPTION
すり切り容量を2.4m³→2.0m³に修正（実測値ベース）
山盛り容量も2.6m³に調整（×1.3係数）