### PR TITLE
security: remove GEMINI_API_KEY from vite define (fixes P0 of #58)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { execSync } from 'child_process';
 
@@ -13,7 +13,6 @@ const getGitCommitHash = () => {
 };
 
 export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, '.', '');
     const commitHash = getGitCommitHash();
     return {
       base: mode === 'production' ? '/TonSuuChecker/' : '/',
@@ -23,8 +22,6 @@ export default defineConfig(({ mode }) => {
       },
       plugins: [react()],
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         '__COMMIT_HASH__': JSON.stringify(commitHash),
       },
       resolve: {


### PR DESCRIPTION
## Summary

P0 security fix for issue #58. Vite の `define` ブロックは指定された値をクライアントバンドルに**ハードコードとして埋め込む**仕様のため、ビルド時に `.env` から `loadEnv` で読み込んだ `GEMINI_API_KEY` が `dist/**/*.js` に漏洩していた。

参考: [Qiita記事 — Viteのdefineブロックによる環境変数漏洩](https://qiita.com/pythonista0328/items/f9eb8b7fb6a14087df35)

## Changes

`vite.config.ts`:
- `define` から `'process.env.API_KEY'` と `'process.env.GEMINI_API_KEY'` を削除 (残すのは `__COMMIT_HASH__` のみ)
- 未使用となった `const env = loadEnv(mode, '.', '');` を削除
- 未使用となった `loadEnv` インポートを削除

クライアント側の API キーは既存の `localStorage.getItem('gemini_api_key')` 経路に一本化される (既に実装済み)。`scripts/readBoards.ts` は Node.js スクリプトで `process.env.GEMINI_API_KEY` を使うが、これはサーバー/CI 実行時のみで Vite バンドルの対象外のため影響なし。

## Verification

- `npm run build` 成功 (vite 6.4.1, 2389 modules, 8.43s)
- `grep -rE 'AIza[A-Za-z0-9_-]{35}' dist/` → マッチなし
- `grep -rE 'process\.env\.(GEMINI_)?API_KEY' dist/` → マッチなし

## Scope

`refs #58` — issue #58 の P0 項目 (Vite define による API キー漏洩) のみを対応。他のチェックボックス項目 (既存漏洩キーの revoke、.env の gitignore 確認、履歴からの除去など) は本 PR の対象外で、別 PR / 別作業で追従する。そのため `Fixes #58` ではなく `refs #58` を使用。

## Test plan

- [x] `npm run build` が成功する
- [x] `dist/` 配下に Gemini API キーパターン (`AIza...`) が含まれない
- [x] `dist/` 配下に `process.env.GEMINI_API_KEY` / `process.env.API_KEY` の文字列が残存しない
- [ ] マージ後に GitHub Pages デプロイでアプリが動作することを手動確認 (localStorage 経由のキー入力 UI 経路)

---

Refs #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)